### PR TITLE
firestore emulatorの追加

### DIFF
--- a/compose.local.yml
+++ b/compose.local.yml
@@ -1,7 +1,11 @@
-version: "3.9"
-
 services:
   firestore:
     image: mtlynch/firestore-emulator
+    healthcheck:
+      test: ["CMD-SHELL", "curl localhost:8080"]
+      interval: 1m30s
+      timeout: 30s
+      retries: 5
+      start_period: 30s
     ports:
       - 8080:8080

--- a/compose.local.yml
+++ b/compose.local.yml
@@ -1,0 +1,7 @@
+version: "3.9"
+
+services:
+  firestore:
+    image: mtlynch/firestore-emulator
+    ports:
+      - 8080:8080


### PR DESCRIPTION
### やったこと
ローカル環境のデバッグで使えるfirestore emulatorの導入。
なんかdocker image があったのでそのまま使っちゃいました() https://hub.docker.com/r/mtlynch/firestore-emulator

- エミュレータに対するpythonクライアントの動作は以下の通り。
  - `FIRESTORE_EMULATOR_HOST` 環境変数がある場合はemulatorにつなぎにいく。
    - `os.environ["FIRESTORE_EMULATOR_HOST"]=...` でpython上で指定してもOK
  - ない場合は、`firebase.json` (firebaseの認証ファイル) をもとに実プロジェクトにつなぎにいく。
- DBデータの出し入れはエミュレータと実環境で同一だが、エミュレータはコンテナ落とすとデータ消失する。

### 確認事項
- この時点でデータスキーマについて合意をとっておきたいです。
```
collection "CoCPlayer": {
  document "guild-1": {
    collection "channels: {
      document "channel-1": {
        "user-1": "url-1",
      }
    }
  }
}
```
参考: https://cloud.google.com/firestore/docs/data-model?hl=ja#python_3